### PR TITLE
Upgrade BeautifulSoup4 and declare parser explicitly

### DIFF
--- a/penn/laundry.py
+++ b/penn/laundry.py
@@ -31,7 +31,7 @@ class Laundry(object):
         r = requests.get(ALL_URL)
         r.raise_for_status()
 
-        parsed = BeautifulSoup(r.text)
+        parsed = BeautifulSoup(r.text, 'html5lib')
         info_table = parsed.find_all('table')[2]
 
         # This bit of code generates a dict of hallname->hall number by

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 nose==1.3.4
 requests==2.4.3
-beautifulsoup4==4.3.2
+beautifulsoup4==4.4.1
 html5lib==0.999


### PR DESCRIPTION
BeautifulSoup 4.4+ is required for Python 3.5, and later version of BS4 give warning about using parser without declaring it automatically.