### PR TITLE
Change the non-update status to -1, add underscores in high rise halls

### DIFF
--- a/penn/__init__.py
+++ b/penn/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.5.3'
+__version__ = '1.6.4'
 
 from .registrar import Registrar
 from .directory import Directory

--- a/penn/laundry.py
+++ b/penn/laundry.py
@@ -48,6 +48,8 @@ class Laundry(object):
         for hall in halls:
             hall_name = hall.contents[0].string
             hall_name = hall_name.replace("/", " ") # convert / to space
+            if hall_name.split()[0] in ["Harrison", "Harnwell", "Rodin"]:
+                hall_name = hall_name.replace(" ", "_", 1)
             self.hall_to_link[hall_name] = ALL_URL + hall.contents[0]['href']
             self.id_to_hall[str(counter)] = hall_name
             self.hall_id_list.append({"hall_name": hall_name, "id": counter})
@@ -73,7 +75,7 @@ class Laundry(object):
         # edge case that handles machine not sending time data
         diff = int(machine_object["running"]) - len(machine_object["time_remaining"])
         while diff > 0:
-            machine_object["time_remaining"].append("not updating status")
+            machine_object["time_remaining"].append(-1)
             diff = diff - 1
 
         return machine_object

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/pennlabs/penn-sdk-python',
     author='Penn Labs',
     author_email='admin@pennlabs.org',
-    version='1.6.3',
+    version='1.6.4',
     packages=['penn'],
     license='MIT',
     package_data={


### PR DESCRIPTION
- Changed `not updating status` to -1 for consistency purposes.
- Add underscores to the High Rise hall names to check what the building name is.