### PR TITLE
Return location in hall response and various fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE.txt README.md CHANGES.txt penn/data/laundry.csv

--- a/penn/__init__.py
+++ b/penn/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.6.5'
+__version__ = '1.6.6'
 
 from .registrar import Registrar
 from .directory import Directory

--- a/penn/base.py
+++ b/penn/base.py
@@ -24,7 +24,7 @@ class WrapperBase(object):
         """Make a signed request to the API, raise any API errors, and
         returning a tuple of (data, metadata)
         """
-        response = get(url, params=params, headers=self.headers, timeout=10)
+        response = get(url, params=params, headers=self.headers, timeout=20)
         if response.status_code != 200:
             raise ValueError('Request to {} returned {}'
                              .format(response.url, response.status_code))

--- a/penn/laundry.py
+++ b/penn/laundry.py
@@ -34,6 +34,7 @@ class Laundry(object):
                      'Saturday', 'Sunday']
         self.hall_to_link = {}
         self.id_to_hall = {}
+        self.id_to_location = {}
         self.hall_id_list = []
         self.create_hall_to_link_mapping()
 
@@ -49,6 +50,7 @@ class Laundry(object):
                 hall_id = int(hall_id)
                 self.hall_to_link[hall_name] = ALL_URL + uuid
                 self.id_to_hall[hall_id] = hall_name
+                self.id_to_location[hall_id] = location
                 self.hall_id_list.append({"hall_name": hall_name, "id": hall_id, "location": location})
 
 
@@ -125,11 +127,13 @@ class Laundry(object):
         >>> english_house = l.hall_status("English%20House")
         """
         hall_name = self.id_to_hall[hall_id]
+        location = self.id_to_location[hall_id]
         machines = self.parse_a_hall((urllib2.unquote(hall_name)))
 
         return {
             'machines': machines,
-            'hall_name': hall_name
+            'hall_name': hall_name,
+            'location': location
         }
 
     def machine_usage(self, hall_no):

--- a/penn/laundry.py
+++ b/penn/laundry.py
@@ -2,10 +2,6 @@ import re
 import csv
 import requests
 import pkg_resources
-try:
-    import urllib2
-except:
-    import urllib.parse as urlib2
 from bs4 import BeautifulSoup
 
 ALL_URL = 'http://suds.kite.upenn.edu/?location='
@@ -52,7 +48,6 @@ class Laundry(object):
                 self.id_to_hall[hall_id] = hall_name
                 self.id_to_location[hall_id] = location
                 self.hall_id_list.append({"hall_name": hall_name, "id": hall_id, "location": location})
-
 
     @staticmethod
     def update_machine_object(cols, machine_object):
@@ -120,15 +115,18 @@ class Laundry(object):
         """Return the status of each specific washer/dryer in a particular
         laundry room.
 
-        :param hall_name:
-             Unescaped string corresponding to the name of the hall hall. This name
+        :param hall_id:
+             Integer corresponding to the id of the hall. This id
              is returned as part of the all_status call.
 
         >>> english_house = l.hall_status("English%20House")
         """
+        if hall_id not in self.id_to_hall:
+            raise ValueError("No hall with id %s exists." % hall_id)
+
         hall_name = self.id_to_hall[hall_id]
         location = self.id_to_location[hall_id]
-        machines = self.parse_a_hall((urllib2.unquote(hall_name)))
+        machines = self.parse_a_hall(hall_name)
 
         return {
             'machines': machines,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/pennlabs/penn-sdk-python',
     author='Penn Labs',
     author_email='admin@pennlabs.org',
-    version='1.6.5',
+    version='1.6.6',
     packages=['penn'],
     license='MIT',
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     package_data={
         # If any package contains *.txt or *.rst files, include them:
         '': ['*.txt', '*.rst'],
+        'penn': ['data/laundry.csv'],
     },
     long_description=open('./README.rst').read(),
     install_requires=[


### PR DESCRIPTION
- Implement #84, return location in individual hall endpoint.
- Remove the `urllib2.unquote`, since `hall_name`s should not be in quoted form in `id_to_hall`.
- Add `laundry.csv` to package data, this is necessary or the file is not copied over when the package is installed.