### PR TITLE
Adding Group IDs to Study Spaces endpoint

### DIFF
--- a/penn/data/locations.json
+++ b/penn/data/locations.json
@@ -1,0 +1,68 @@
+{
+    "locations": [
+                  {
+                  "lid": 1086,
+                  "gid": 1889,
+                  "name": "Weigle",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 1086,
+                  "gid": 4660,
+                  "name": "VP Ground Floor",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 1086,
+                  "gid": 4659,
+                  "name": "VP 3rd Floor",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 1086,
+                  "gid": 1891,
+                  "name": "VP 4th Floor",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2587,
+                  "name": "Lippincott",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2683,
+                  "name": "Biomedical Library",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2495,
+                  "name": "Education Commons",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2637,
+                  "name": "Fisher Fine Arts",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 1090,
+                  "name": "Levin Building",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2634,
+                  "name": "Museum Library",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2636,
+                  "name": "VP Seminar",
+                  "service": "libcal"
+                  },
+                  {
+                  "lid": 2611,
+                  "name": "VP Special Use",
+                  "service": "libcal"
+                  }
+                ]
+}

--- a/penn/data/locations.json
+++ b/penn/data/locations.json
@@ -29,13 +29,13 @@
                   "service": "libcal"
                   },
                   {
-                  "lid": 2683,
-                  "name": "Biomedical Library",
+                  "lid": 2495,
+                  "name": "Education Commons",
                   "service": "libcal"
                   },
                   {
-                  "lid": 2495,
-                  "name": "Education Commons",
+                  "lid": 2683,
+                  "name": "Biomedical Library",
                   "service": "libcal"
                   },
                   {

--- a/penn/data/locations.json
+++ b/penn/data/locations.json
@@ -1,5 +1,4 @@
-{
-    "locations": [
+[
                   {
                   "lid": 1086,
                   "gid": 1889,
@@ -65,4 +64,4 @@
                   "service": "libcal"
                   }
                 ]
-}
+

--- a/penn/data/locations.json
+++ b/penn/data/locations.json
@@ -25,41 +25,49 @@
                   },
                   {
                   "lid": 2587,
+                  "gid": 4368,
                   "name": "Lippincott",
                   "service": "libcal"
                   },
                   {
                   "lid": 2495,
+                  "gid": 1886,
                   "name": "Education Commons",
                   "service": "libcal"
                   },
                   {
                   "lid": 2683,
+                  "gid": 1885,
                   "name": "Biomedical Library",
                   "service": "libcal"
                   },
                   {
                   "lid": 2637,
+                  "gid": 1904,
                   "name": "Fisher Fine Arts",
                   "service": "libcal"
                   },
                   {
                   "lid": 1090,
+                  "gid": 1909,
                   "name": "Levin Building",
                   "service": "libcal"
                   },
                   {
                   "lid": 2634,
+                  "gid": 1914,
                   "name": "Museum Library",
                   "service": "libcal"
                   },
                   {
                   "lid": 2636,
+                  "gid": 4887,
                   "name": "VP Seminar",
                   "service": "libcal"
                   },
                   {
                   "lid": 2611,
+                  "gid": 4748,
                   "name": "VP Special Use",
                   "service": "libcal"
                   }

--- a/penn/studyspaces.py
+++ b/penn/studyspaces.py
@@ -28,8 +28,8 @@ class StudySpaces(object):
         """Returns a list of building IDs, building names, and services."""
 
         location_path = pkg_resources.resource_filename("penn", "data/locations.json")
-        with open(location_path, "r") as locations:
-            return locations
+        with open(location_path, "r") as location:
+            return location
         # soup = BeautifulSoup(requests.get("{}/spaces".format(BASE_URL)).content, "html5lib")
         # options = soup.find("select", {"id": "lid"}).find_all("option")
         # return [{"id": int(opt["value"]), "name": str(opt.text), "service": "libcal"} for opt in options if int(opt["value"]) > 0]

--- a/penn/studyspaces.py
+++ b/penn/studyspaces.py
@@ -4,6 +4,7 @@ import json
 import pytz
 import re
 import six
+import pkg_resources
 
 from bs4 import BeautifulSoup
 
@@ -25,10 +26,13 @@ class StudySpaces(object):
 
     def get_buildings(self):
         """Returns a list of building IDs, building names, and services."""
-        
-        soup = BeautifulSoup(requests.get("{}/spaces".format(BASE_URL)).content, "html5lib")
-        options = soup.find("select", {"id": "lid"}).find_all("option")
-        return [{"id": int(opt["value"]), "name": str(opt.text), "service": "libcal"} for opt in options if int(opt["value"]) > 0]
+
+        location_path = pkg_resources.resource_filename("penn", "data/locations.json")
+        with open(location_path, "r") as locations:
+            return locations
+        # soup = BeautifulSoup(requests.get("{}/spaces".format(BASE_URL)).content, "html5lib")
+        # options = soup.find("select", {"id": "lid"}).find_all("option")
+        # return [{"id": int(opt["value"]), "name": str(opt.text), "service": "libcal"} for opt in options if int(opt["value"]) > 0]
 
     def book_room(self, building, room, start, end, firstname, lastname, email, groupname, phone, size, fake=False):
         """Books a room given the required information.

--- a/penn/studyspaces.py
+++ b/penn/studyspaces.py
@@ -28,8 +28,8 @@ class StudySpaces(object):
         """Returns a list of building IDs, building names, and services."""
 
         location_path = pkg_resources.resource_filename("penn", "data/locations.json")
-        with open(location_path, "r") as location:
-            return location
+        with open(location_path, "r") as locations:
+            return json.loads(locations.read())
         # soup = BeautifulSoup(requests.get("{}/spaces".format(BASE_URL)).content, "html5lib")
         # options = soup.find("select", {"id": "lid"}).find_all("option")
         # return [{"id": int(opt["value"]), "name": str(opt.text), "service": "libcal"} for opt in options if int(opt["value"]) > 0]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={
         # If any package contains *.txt or *.rst files, include them:
         '': ['*.txt', '*.rst'],
-        'penn': ['data/laundry.csv'],
+        'penn': ['data/laundry.csv', 'data/locations.json'],
     },
     long_description=open('./README.rst').read(),
     install_requires=[

--- a/tests/studyspaces_test.py
+++ b/tests/studyspaces_test.py
@@ -27,7 +27,7 @@ class TestStudySpaces():
         now = datetime.datetime.now()
         buildings = self.studyspaces.get_buildings()
         for building in buildings[:3]:
-            rooms = self.studyspaces.get_rooms(building["id"], now, now + datetime.timedelta(days=3))
+            rooms = self.studyspaces.get_rooms(building["lid"], now, now + datetime.timedelta(days=3))
             ok_(len(rooms) > 0, "The building {} does not have any rooms!".format(building))
             for room in rooms:
                 ok_(room["room_id"] > 0)
@@ -38,7 +38,7 @@ class TestStudySpaces():
 
         buildings = self.studyspaces.get_buildings()
         # get the first building
-        building_id = buildings[0]["id"]
+        building_id = buildings[0]["lid"]
 
         now = datetime.datetime.now()
         rooms = self.studyspaces.get_rooms(building_id, now, now + datetime.timedelta(days=1))

--- a/tests/studyspaces_test.py
+++ b/tests/studyspaces_test.py
@@ -13,7 +13,7 @@ class TestStudySpaces():
         buildings = self.studyspaces.get_buildings()
         ok_(len(buildings) > 0)
         for building in buildings:
-            ok_(building["id"] > 0)
+            ok_(building["lid"] > 0)
             ok_(building["name"])
             ok_(building["service"])
 


### PR DESCRIPTION
Rooms in locations that have multiple groups now have group id (gid) tags to group them together (Weigle, 3rd Floor, 4th floor, etc.). Location names have also been changed to more usable and descriptive ones. Because of these custom tweaks, this JSON is hardcoded and is no longer fetched by scraping the site. 